### PR TITLE
fixed the greying out of the web page for modal.

### DIFF
--- a/MPEGDashPlayer/client/MPEGDashPlayer.css
+++ b/MPEGDashPlayer/client/MPEGDashPlayer.css
@@ -119,3 +119,8 @@ button {
 #nav-bar {
     display: inline-block;
 }
+
+.modal-backdrop { 
+    z-index: auto;
+}
+/*.modal { background: rgba(000, 000, 000, 0.8); min-height:1000000px; }*/

--- a/MPEGDashPlayer/client/MPEGDashPlayer.html
+++ b/MPEGDashPlayer/client/MPEGDashPlayer.html
@@ -66,7 +66,7 @@
 
 
 <template name="videoModal">
-	<div class="modal fade" id="addVideoModal" tabindex="-1" role="dialog" aria-labelledby="addVideosLabel">
+	<div class="modal fade" id="addVideoModal" tabindex="-1" role="dialog" aria-labelledby="addVideosLabel"> <!-- data-backdrop="false"> -->
 		<div class="modal-dialog" role="document">
 			<div class="modal-content">
 				<div class="modal-header">
@@ -95,7 +95,7 @@
 </template>
 
 <template name="launchModal">
-	<div class="modal fade" id="launchVideoModal" tabindex="-1" role="dialog" aria-labelledby="launchLabel">
+	<div class="modal fade" id="launchVideoModal" tabindex="-1" role="dialog" aria-labelledby="launchLabel"> <!-- data-backdrop="false"> -->
 		<div class="modal-dialog" role="document">
 			<div class="modal-content">
 				<div class="modal-header">


### PR DESCRIPTION
We were getting an error with the positioning of the z-index after the tiling.  
There is two different ways to fix it:
One, the modal pops up and you can close it by the button or by clicking off, but everything behind the modal is not greyed out.  There may be a way to put the modal just in front of the greyed background but I couldn't figure it out.
Two, the modal pops up and greys out everything behind the modal, but you can only close it with the close button at the bottom.  
