### PR TITLE
There was an ajax call that caused the tiling function to error out.

### DIFF
--- a/MPEGDashPlayer/client/MPEGDashPlayer.js
+++ b/MPEGDashPlayer/client/MPEGDashPlayer.js
@@ -97,11 +97,11 @@ TilingHelper = {
 Template.tiling.events({
   'click #tile': function(){
 
-    $.ajax({
-      type: "POST",
-      url: "http://137.112.104.147:8088/",
-      data: x
-    });
+    // $.ajax({
+    //   type: "POST",
+    //   url: "http://137.112.104.147:8088/",
+    //   data: x
+    // });
 	
 	var DISPLAY_WIDTH = parseInt($("#display").css("width"), 10);
 	top = 0;


### PR DESCRIPTION
The ajax call didn't seem like it should be there.

I was looking into to fixing the resizing error that would happen when we tiled the videos, but I was unable to recreate the error.
